### PR TITLE
Replace JSR223 user setup; update port and pacing

### DIFF
--- a/src/test/java/jmeter/load/register-login-load.jmx
+++ b/src/test/java/jmeter/load/register-login-load.jmx
@@ -16,7 +16,7 @@
           </elementProp>
           <elementProp name="port" elementType="Argument">
             <stringProp name="Argument.name">port</stringProp>
-            <stringProp name="Argument.value">7008</stringProp>
+            <stringProp name="Argument.value">7007</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>
@@ -31,7 +31,7 @@
         <stringProp name="ThreadGroup.duration">120</stringProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">true</boolProp>
-        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <stringProp name="ThreadGroup.on_sample_error">startnextloop</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
           <intProp name="LoopController.loops">-1</intProp>
           <boolProp name="LoopController.continue_forever">true</boolProp>
@@ -50,15 +50,6 @@
             </elementProp>
           </collectionProp>
         </HeaderManager>
-        <hashTree/>
-        <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="Prepare unique test user" enabled="true">
-          <stringProp name="scriptLanguage">groovy</stringProp>
-          <stringProp name="parameters"/>
-          <stringProp name="filename"/>
-          <stringProp name="cacheKey">true</stringProp>
-          <stringProp name="script">vars.put('username', 'jl_' + ctx.getThreadNum() + '_' + Long.toString(vars.getIteration() as long, 36) + '_' + Long.toString(System.currentTimeMillis(), 36))
-vars.put('password', 'P@ssw0rd2026')</stringProp>
-        </JSR223Sampler>
         <hashTree/>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Register account" enabled="true">
           <stringProp name="HTTPSampler.domain">${host}</stringProp>
@@ -80,6 +71,19 @@ vars.put('password', 'P@ssw0rd2026')</stringProp>
           </elementProp>
         </HTTPSamplerProxy>
         <hashTree>
+          <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="Prepare unique test user" enabled="true">
+            <stringProp name="filename"/>
+            <stringProp name="parameters"/>
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="script">synchronized (props) {
+    String key = "jmeter.load.user.counter";
+    long counter = Long.parseLong(props.getProperty(key, "0")) + 1;
+    props.setProperty(key, Long.toString(counter));
+    vars.put("username", "jl" + Long.toString(System.currentTimeMillis(), 36) + Long.toString(counter, 36));
+}
+vars.put("password", "P@ssw0rd2026");</stringProp>
+          </BeanShellPreProcessor>
+          <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Register should return 201" enabled="true">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="201">201</stringProp>
@@ -120,6 +124,10 @@ vars.put('password', 'P@ssw0rd2026')</stringProp>
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Pacing - 250 ms" enabled="true">
+          <stringProp name="ConstantTimer.delay">250</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
     </hashTree>
   </hashTree>

--- a/src/test/java/jmeter/spike/register-login-spike.jmx
+++ b/src/test/java/jmeter/spike/register-login-spike.jmx
@@ -10,13 +10,13 @@
         <collectionProp name="Arguments.arguments">
           <elementProp name="protocol" elementType="Argument"><stringProp name="Argument.name">protocol</stringProp><stringProp name="Argument.value">http</stringProp><stringProp name="Argument.metadata">=</stringProp></elementProp>
           <elementProp name="host" elementType="Argument"><stringProp name="Argument.name">host</stringProp><stringProp name="Argument.value">localhost</stringProp><stringProp name="Argument.metadata">=</stringProp></elementProp>
-          <elementProp name="port" elementType="Argument"><stringProp name="Argument.name">port</stringProp><stringProp name="Argument.value">7008</stringProp><stringProp name="Argument.metadata">=</stringProp></elementProp>
+          <elementProp name="port" elementType="Argument"><stringProp name="Argument.name">port</stringProp><stringProp name="Argument.value">7007</stringProp><stringProp name="Argument.metadata">=</stringProp></elementProp>
         </collectionProp>
       </elementProp>
     </TestPlan>
     <hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Spike - 100 users" enabled="true">
-        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <stringProp name="ThreadGroup.on_sample_error">startnextloop</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">true</boolProp>
           <intProp name="LoopController.loops">-1</intProp>
@@ -36,15 +36,6 @@
           </collectionProp>
         </HeaderManager>
         <hashTree/>
-        <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="Prepare unique test user" enabled="true">
-          <stringProp name="cacheKey">true</stringProp>
-          <stringProp name="filename"></stringProp>
-          <stringProp name="parameters"></stringProp>
-          <stringProp name="script">vars.put('username', 'jp_' + ctx.getThreadNum() + '_' + Long.toString(vars.getIteration() as long, 36) + '_' + Long.toString(System.currentTimeMillis(), 36))
-vars.put('password', 'P@ssw0rd2026')</stringProp>
-          <stringProp name="scriptLanguage">groovy</stringProp>
-        </JSR223Sampler>
-        <hashTree/>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Register account" enabled="true">
           <stringProp name="HTTPSampler.domain">${host}</stringProp>
           <stringProp name="HTTPSampler.port">${port}</stringProp>
@@ -57,6 +48,19 @@ vars.put('password', 'P@ssw0rd2026')</stringProp>
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments"><collectionProp name="Arguments.arguments"><elementProp name="" elementType="HTTPArgument"><boolProp name="HTTPArgument.always_encode">false</boolProp><stringProp name="Argument.value">{&quot;username&quot;:&quot;${username}&quot;,&quot;password&quot;:&quot;${password}&quot;}</stringProp><stringProp name="Argument.metadata">=</stringProp></elementProp></collectionProp></elementProp>
         </HTTPSamplerProxy>
         <hashTree>
+          <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="Prepare unique test user" enabled="true">
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="script">synchronized (props) {
+    String key = "jmeter.spike.user.counter";
+    long counter = Long.parseLong(props.getProperty(key, "0")) + 1;
+    props.setProperty(key, Long.toString(counter));
+    vars.put("username", "jp" + Long.toString(System.currentTimeMillis(), 36) + Long.toString(counter, 36));
+}
+vars.put("password", "P@ssw0rd2026");</stringProp>
+          </BeanShellPreProcessor>
+          <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Register should return 201" enabled="true"><collectionProp name="Asserion.test_strings"><stringProp name="49587">201</stringProp></collectionProp><stringProp name="Assertion.test_field">Assertion.response_code</stringProp><boolProp name="Assertion.assume_success">false</boolProp><intProp name="Assertion.test_type">8</intProp></ResponseAssertion>
           <hashTree/>
         </hashTree>
@@ -75,6 +79,10 @@ vars.put('password', 'P@ssw0rd2026')</stringProp>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Login should return 200" enabled="true"><collectionProp name="Asserion.test_strings"><stringProp name="49586">200</stringProp></collectionProp><stringProp name="Assertion.test_field">Assertion.response_code</stringProp><boolProp name="Assertion.assume_success">false</boolProp><intProp name="Assertion.test_type">8</intProp></ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Pacing - 100 ms" enabled="true">
+          <stringProp name="ConstantTimer.delay">100</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
     </hashTree>
   </hashTree>

--- a/src/test/java/jmeter/stress/register-login-stress.jmx
+++ b/src/test/java/jmeter/stress/register-login-stress.jmx
@@ -10,13 +10,13 @@
         <collectionProp name="Arguments.arguments">
           <elementProp name="protocol" elementType="Argument"><stringProp name="Argument.name">protocol</stringProp><stringProp name="Argument.value">http</stringProp><stringProp name="Argument.metadata">=</stringProp></elementProp>
           <elementProp name="host" elementType="Argument"><stringProp name="Argument.name">host</stringProp><stringProp name="Argument.value">localhost</stringProp><stringProp name="Argument.metadata">=</stringProp></elementProp>
-          <elementProp name="port" elementType="Argument"><stringProp name="Argument.name">port</stringProp><stringProp name="Argument.value">7008</stringProp><stringProp name="Argument.metadata">=</stringProp></elementProp>
+          <elementProp name="port" elementType="Argument"><stringProp name="Argument.name">port</stringProp><stringProp name="Argument.value">7007</stringProp><stringProp name="Argument.metadata">=</stringProp></elementProp>
         </collectionProp>
       </elementProp>
     </TestPlan>
     <hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Stress - 50 users" enabled="true">
-        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <stringProp name="ThreadGroup.on_sample_error">startnextloop</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">true</boolProp>
           <intProp name="LoopController.loops">-1</intProp>
@@ -36,15 +36,6 @@
           </collectionProp>
         </HeaderManager>
         <hashTree/>
-        <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="Prepare unique test user" enabled="true">
-          <stringProp name="cacheKey">true</stringProp>
-          <stringProp name="filename"></stringProp>
-          <stringProp name="parameters"></stringProp>
-          <stringProp name="script">vars.put('username', 'js_' + ctx.getThreadNum() + '_' + Long.toString(vars.getIteration() as long, 36) + '_' + Long.toString(System.currentTimeMillis(), 36))
-vars.put('password', 'P@ssw0rd2026')</stringProp>
-          <stringProp name="scriptLanguage">groovy</stringProp>
-        </JSR223Sampler>
-        <hashTree/>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Register account" enabled="true">
           <stringProp name="HTTPSampler.domain">${host}</stringProp>
           <stringProp name="HTTPSampler.port">${port}</stringProp>
@@ -57,6 +48,19 @@ vars.put('password', 'P@ssw0rd2026')</stringProp>
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments"><collectionProp name="Arguments.arguments"><elementProp name="" elementType="HTTPArgument"><boolProp name="HTTPArgument.always_encode">false</boolProp><stringProp name="Argument.value">{&quot;username&quot;:&quot;${username}&quot;,&quot;password&quot;:&quot;${password}&quot;}</stringProp><stringProp name="Argument.metadata">=</stringProp></elementProp></collectionProp></elementProp>
         </HTTPSamplerProxy>
         <hashTree>
+          <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="Prepare unique test user" enabled="true">
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="script">synchronized (props) {
+    String key = "jmeter.stress.user.counter";
+    long counter = Long.parseLong(props.getProperty(key, "0")) + 1;
+    props.setProperty(key, Long.toString(counter));
+    vars.put("username", "js" + Long.toString(System.currentTimeMillis(), 36) + Long.toString(counter, 36));
+}
+vars.put("password", "P@ssw0rd2026");</stringProp>
+          </BeanShellPreProcessor>
+          <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Register should return 201" enabled="true"><collectionProp name="Asserion.test_strings"><stringProp name="49587">201</stringProp></collectionProp><stringProp name="Assertion.test_field">Assertion.response_code</stringProp><boolProp name="Assertion.assume_success">false</boolProp><intProp name="Assertion.test_type">8</intProp></ResponseAssertion>
           <hashTree/>
         </hashTree>


### PR DESCRIPTION
## Beskrivelse
Update JMeter test plans for load, spike and stress scenarios: change default port from 7008 to 7007 and set ThreadGroup.on_sample_error to startnextloop. Replace the inline JSR223Sampler Groovy user-prep with a synchronized BeanShellPreProcessor that increments a shared props counter and builds a unique username (per-test keys: jmeter.load.user.counter, jmeter.spike.user.counter, jmeter.stress.user.counter) and sets a static password. Add pacing ConstantTimer entries to the load (250 ms) and spike (100 ms) tests to control request spacing. These changes standardize user generation across tests and adjust runtime behavior/error handling and target port.

## Tjekliste
- [x] Koden er testet lokalt
- [ ] Relevante tests er opdateret eller tilføjet
- [x] Ændringerne er gennemgået
