### PR TITLE
Enable test mode and adjust Testcontainers scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ Email: admin@admin.com
 Password: admin
 ```
 
+## Start backend i normal mode eller test mode
+
+I `src/main/java/application/Application.java` bestemmer denne linje om backend starter i normal mode eller test mode:
+
+```java
+boolean isTest = false;
+```
+
+Brug `false` for normal mode med PostgreSQL fra Docker Compose.
+Brug `true` for test mode med Testcontainers og en midlertidig PostgreSQL-container. Docker Desktop skal vaere startet i test mode.
+
+```powershell
+mvn package
+java -jar target\app.jar
+```
+
 ## Kør tests og generer JaCoCo rapport
 
 ```powershell

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -45,6 +45,23 @@
               <goal>report</goal>
             </goals>
           </execution>
+          <execution>
+            <id>merge-jacoco-exec</id>
+            <goals>
+              <goal>merge</goal>
+            </goals>
+            <configuration>
+              <fileSets>
+                <fileSet>
+                  <directory>${project.build.directory}/jacoco-exec</directory>
+                  <includes>
+                    <include>**/*.exec</include>
+                  </includes>
+                </fileSet>
+              </fileSets>
+              <destFile>${project.build.directory}/jacoco.exec</destFile>
+            </configuration>
+          </execution>
         </executions>
         <configuration>
           <excludes>
@@ -97,48 +114,6 @@
       <artifactId>lombok</artifactId>
       <version>1.18.28</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers</artifactId>
-      <version>2.0.5</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>commons-compress</artifactId>
-          <groupId>org.apache.commons</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>duct-tape</artifactId>
-          <groupId>org.rnorth.duct-tape</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>docker-java-api</artifactId>
-          <groupId>com.github.docker-java</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>docker-java-transport-zerodep</artifactId>
-          <groupId>com.github.docker-java</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers-postgresql</artifactId>
-      <version>2.0.5</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers-jdbc</artifactId>
-      <version>2.0.5</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>testcontainers-database-commons</artifactId>
-          <groupId>org.testcontainers</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
@@ -220,7 +195,6 @@
     <maven.compiler.source>17</maven.compiler.source>
     <testcontainers.version>2.0.5</testcontainers.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <sonar.coverage.exclusions>**/application/config/**,
-            **/persistence/config/**</sonar.coverage.exclusions>
+    <sonar.coverage.exclusions>**/application/*.java,**/application/**,**/application/config/**,**/persistence/config/**</sonar.coverage.exclusions>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,19 +81,19 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-postgresql</artifactId>
             <version>${testcontainers.version}</version>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-jdbc</artifactId>
             <version>${testcontainers.version}</version>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/src/main/java/application/Application.java
+++ b/src/main/java/application/Application.java
@@ -7,14 +7,14 @@ import route.Route;
 
 @lombok.Generated
 public class Application {
-    
-    public static void main(String[] args) {
-        EntityManagerFactory emf = HibernateConfig.getEntityManagerFactoryConfig(false);
 
-        Route route = new Route(emf);
-        ApplicationConfig app = ApplicationConfig.getInstance();
-        app.initiateServer()
+    public static void main(String[] args) {
+        boolean isTest = true;
+        EntityManagerFactory emf = HibernateConfig.getEntityManagerFactoryConfig(isTest);
+
+        ApplicationConfig.getInstance()
+                .initiateServer()
                 .startServer(7007)
-                .setRoute(route.addRoutes());
+                .setRoute(new Route(emf).addRoutes());
     }
 }


### PR DESCRIPTION
## Beskrivelse
Add README instructions for starting backend in normal vs test mode. Update Application.java to toggle test mode (isTest = true) and pass EntityManagerFactory into Route during server startup. Change Testcontainers dependencies scope from test to runtime in pom.xml so containers can be used at runtime, and update sonar coverage exclusions. Add a JaCoCo merge execution in dependency-reduced-pom.xml and remove duplicate Testcontainers dependency declarations there.

## Tjekliste
- [x] Koden er testet lokalt
- [ ] Relevante tests er opdateret eller tilføjet
- [x] Ændringerne er gennemgået
